### PR TITLE
fix path traversal issue in function extract

### DIFF
--- a/extract.go
+++ b/extract.go
@@ -5,6 +5,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
+     securejoin "github.com/cyphar/filepath-securejoin"
+
 )
 
 func yesNoAllNoneQuit(fname string) (string, error) {
@@ -21,9 +24,20 @@ func extract(fileName string, files []string, verbose bool, log io.Writer) error
 	}
 	openModeDefault := os.O_WRONLY | os.O_CREATE | os.O_EXCL
 	alwaysNone := false
+	rootAbs, err := filepath.Abs(".")
+	if err != nil {
+	    return err
+	}
 	return doEach(fileName, files, func(name string, sc *ZipScanner) error {
 		name = filepath.FromSlash(stripDriveLetterAndRoot(name))
+        name = strings.TrimLeft(name, string(filepath.Separator))
+
+		 name, err := securejoin.SecureJoin(rootAbs, name)
+		 if err != nil {
+			return err
+		    }
 		fileInfo := sc.FileInfo()
+
 		if fileInfo.IsDir() {
 			fmt.Fprintln(log, "mkdir", name)
 			mode := fileInfo.Mode()


### PR DESCRIPTION
fix path traversal bug, ensuring the archive extraction files are inside the intended directory.